### PR TITLE
Update tss-esapi crate and add serde default attributes as needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_repr = "0.1"
 serde_bytes = "0.11"
 serde_with = { version = "1.5", default_features = false }
 openssl = "0.10"
-tss-esapi = { version = "6.1", optional = true }
+tss-esapi = { version = "7.1", optional = true }
 
 [dependencies.serde]
 version = "1.0"

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -135,8 +135,10 @@ pub struct SigStructure(
     #[serde(skip_serializing_if = "Option::is_none")]
     Option<ByteBuf>,
     /// external_aad : bstr,
+    #[serde(default)]
     ByteBuf,
     /// payload : bstr
+    #[serde(default)]
     ByteBuf,
 );
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,5 +1,6 @@
 //! COSE Signing
 
+use std::fmt;
 use std::str::FromStr;
 
 use openssl::hash::{hash, MessageDigest};
@@ -60,14 +61,13 @@ impl FromStr for SignatureAlgorithm {
     }
 }
 
-impl ToString for SignatureAlgorithm {
-    fn to_string(&self) -> String {
+impl fmt::Display for SignatureAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SignatureAlgorithm::ES256 => "ES256",
-            SignatureAlgorithm::ES384 => "ES384",
-            SignatureAlgorithm::ES512 => "ES512",
+            SignatureAlgorithm::ES256 => write!(f, "ES256"),
+            SignatureAlgorithm::ES384 => write!(f, "ES384"),
+            SignatureAlgorithm::ES512 => write!(f, "ES512"),
         }
-        .to_string()
     }
 }
 


### PR DESCRIPTION
This repository is used by rust-sgx. The latest updates to serde causes compiler errors while using this branch. Update tss-esapi crate and add serde attributes to resolve compiler errors.